### PR TITLE
Fix facade getcollaterals

### DIFF
--- a/src/facade/borrow/borrow.ts
+++ b/src/facade/borrow/borrow.ts
@@ -126,7 +126,7 @@ export class Borrow {
           const userBalance = await queryCustodyBorrower({
             lcd: this._lcd,
             ...getCollateralsOption,
-            custody: getCollateralsOption.market,
+            custody: whitelist.custody_contract,
           })(this._addressProvider);
 
           if (userBalance.balance === '0') {

--- a/src/facade/borrow/borrow.ts
+++ b/src/facade/borrow/borrow.ts
@@ -93,10 +93,6 @@ export class Borrow {
     );
     const collaterals = await this.getCollaterals(getCollateralValueOption);
 
-    if (collaterals.length === 1 && collaterals[0] === null) {
-      return new Dec(0).toString();
-    }
-
     const total = collaterals.reduce((sum, collateral) => {
       const collateralPrice = oraclePrice.prices.find(
         (p) => p.asset === collateral.collateral,

--- a/src/facade/borrow/borrow.ts
+++ b/src/facade/borrow/borrow.ts
@@ -88,7 +88,6 @@ export class Borrow {
   async getCollateralValue(
     getCollateralValueOption: BorrowQueriesOptions,
   ): Promise<string> {
-    // only bLuna is supported now, and the below requests are only about bLuna
     const oraclePrice = await queryOraclePrices({ lcd: this._lcd, limit: 30 })(
       this._addressProvider,
     );
@@ -128,10 +127,6 @@ export class Borrow {
             ...getCollateralsOption,
             custody: whitelist.custody_contract,
           })(this._addressProvider);
-
-          if (userBalance.balance === '0') {
-            return null;
-          }
 
           return {
             collateral: whitelist.collateral_token,


### PR DESCRIPTION
## Context

I noticed since bETH was introduced Borrow class `getCollaterals` and `getCollateralValue` no longer function.

A case statement was introduced which broke functionality for `AddressFromJsonProvider`. Before this method just returned the custody contract address but now it can return a null value if the switch case on `collateral` doesn't match:

https://github.com/Anchor-Protocol/anchor.js/blob/a4b3da7282cfc0e670af44978fda9505b5833dcd/src/address-provider/from-json.ts#L64-L73

When calling `queryCustodyBorrower` the parameter `custody` is passed with an instance of `MARKET_DENOMS`

https://github.com/Anchor-Protocol/anchor.js/blob/a4b3da7282cfc0e670af44978fda9505b5833dcd/src/facade/borrow/borrow.ts#L126-L130

Then `custody` is then type-casted to type `COLLATERAL_DENOMS` and we just get a null value back

https://github.com/Anchor-Protocol/anchor.js/blob/a4b3da7282cfc0e670af44978fda9505b5833dcd/src/queries/money-market/custody-borrower.ts#L30

## How to reproduce

You can see master branch no longer works running the following from node console:

```js
let walletAddress = 'YOUR_TERRA_WALLET_ADDRESS'

const Terra = require('@terra-money/terra.js')
const AnchorJS = require('./dist/index')

const LCDClient = Terra.LCDClient
const Anchor = AnchorJS.Anchor
const columbus4 = AnchorJS.columbus4
const AddressProviderFromJson = AnchorJS.AddressProviderFromJson

let client = new LCDClient({
  URL: 'https://lcd.terra.dev',
  chainID: 'columbus-4'
})
let provider = new AddressProviderFromJson(columbus4)
let anchor = new Anchor(client, provider)

anchor.borrow.getCollaterals({ market: 'uusd', address: walletAddress }).then(console.log)
anchor.borrow.getCollateralValue({ market: 'uusd', address: walletAddress }).then(console.log)
```