### PR TITLE
feat: update interfaces for new version of contracts

### DIFF
--- a/src/queries/basset/hub-all-history.ts
+++ b/src/queries/basset/hub-all-history.ts
@@ -14,9 +14,13 @@ interface HistoryResponse {
 interface UnbondHistory {
   batch_id: number;
   time: number;
-  amount: string;
+  amount: string; //deprecated
+  bluna_amount: string;
+  stluna_amount: string;
   applied_exchange_rate: string;
-  withdraw_rate: string;
+  withdraw_rate: string; //deprecated
+  bluna_withdraw_rate: string;
+  stluna_withdraw_rate: string;
   released: boolean;
 }
 

--- a/src/queries/basset/hub-config.ts
+++ b/src/queries/basset/hub-config.ts
@@ -7,7 +7,9 @@ interface Option {
 interface ConfigResponse {
   owner: string;
   reward_contract?: string;
-  token_contract?: string;
+  token_contract?: string; //deprecated
+  bluna_token_contract?: string;
+  stluna_token_contract?: string;
   airdrop_registry_contract?: string;
 }
 

--- a/src/queries/basset/hub-current-batch.ts
+++ b/src/queries/basset/hub-current-batch.ts
@@ -7,7 +7,9 @@ interface Option {
 
 interface CurrentBatchResponse {
   id: number;
-  requested_with_fee: string;
+  requested_with_fee: string; //deprecated
+  requested_bluna_with_fee: string;
+  requested_stluna: string;
 }
 
 export const queryHubCurrentBatch =

--- a/src/queries/basset/hub-state.ts
+++ b/src/queries/basset/hub-state.ts
@@ -7,8 +7,12 @@ interface Option {
 }
 
 interface StateResponse {
-  exchange_rate: string;
-  total_bond_amount: string;
+  exchange_rate: string; //deprecated
+  bluna_exchange_rate: string;
+  stluna_exchange_rate: string;
+  total_bond_amount: string; //deprecated
+  total_bond_bluna_amount: string;
+  total_bond_stluna_amount: string;
   last_index_modification: number;
   prev_hub_balance: string;
   actual_unbonded_amount: string;

--- a/src/queries/basset/hub-unbond-requests.ts
+++ b/src/queries/basset/hub-unbond-requests.ts
@@ -8,7 +8,7 @@ interface Option {
 
 export interface UnbondResponse {
   address: string;
-  requests: Array<[number, string]>;
+  requests: Array<[number, string, string]>;
 }
 
 export const queryHubUnbond =


### PR DESCRIPTION
According to the new version of contracts interfaces have been updated. Here is a list of changes:

1. `HubConfig` - added `bluna_token_contract` and `stluna_token_contract`. `token_contract` will equal to `bluna_token_contract`
2. `StateResponse` hub state - added `bluna_exchange_rate`, `stluna_exchange_rate`, `total_bond_bluna_amount`, `total_bond_stluna_amount`.  `exchange_rate` will equal to `bluna_exchange_rate` and `total_bond_amount` = `total_bond_bluna_amount`
3. `UnbondHistory` item of `all_history` response - added `bluna_amount`, `stluna_amount`, `bluna_withdraw_rate`, `stluna_withdraw_rate`. `withdraw_rate` will equal `bluna_withdraw_rate` and `amount` = `bluna_amount`
4. `CurrentBatchResponse` - added `requested_bluna_with_fee` and `requested_stluna_with_fee`. `requested_with_fee` will equal `requested_bluna_with_fee`
5. Added third element into `UnbondResponse` which return `stluna` amount