### PR TITLE
fix: Invalid variant active_bids should be activate_bids

### DIFF
--- a/src/fabricators/money-market/index.ts
+++ b/src/fabricators/money-market/index.ts
@@ -9,7 +9,7 @@ export * from './liquidation-submit-bid';
 export * from './liquidation-retract-bid';
 export * from './liquidation-queue-retract-bid';
 export * from './liquidation-queue-submit-bid';
-export * from './liquidation-queue-active-bids';
+export * from './liquidation-queue-activate-bids';
 export * from './liquidation-queue-claim-liquidation';
 export * from './custody-update-config';
 export * from './custody-withdraw-collateral';

--- a/src/fabricators/money-market/liquidation-queue-activate-bids.ts
+++ b/src/fabricators/money-market/liquidation-queue-activate-bids.ts
@@ -9,7 +9,7 @@ interface Option {
   bids_idx: string[] | undefined;
 }
 
-export const fabricateLiquidationQueueActiveBids =
+export const fabricateLiquidationQueueActivateBids =
   ({ address, bids_idx, collateral_token }: Option) =>
   (addressProvider: AddressProvider): MsgExecuteContract[] => {
     validateInput([validateAddress(address)]);
@@ -18,7 +18,7 @@ export const fabricateLiquidationQueueActiveBids =
 
     return [
       new MsgExecuteContract(address, mmContractAddress, {
-        active_bids: {
+        activate_bids: {
           bids_idx: bids_idx,
           collateral_token: collateral_token,
         },


### PR DESCRIPTION
The message fabrication for `activateBids` is incorrect. This PR renames `active_bids` to `activate_bids`. The following error occurs when trying to broadcast the malformed message:

```
failed to execute message; message index: 0: Error parsing into type moneymarket::liquidation_queue::ExecuteMsg: unknown variant `active_bids`, expected one of `receive`, `update_config`, `whitelist_collateral`, `update_collateral_info`, `submit_bid`, `retract_bid`, `activate_bids`, `claim_liquidation`
```

Documentation: https://docs.anchorprotocol.com/smart-contracts/liquidations/liquidation-queue-contract#activatebids